### PR TITLE
Set HADOOP_MAPRED_HOME after env vars leaking from the NM was removed…

### DIFF
--- a/conf/mapred-site.xml
+++ b/conf/mapred-site.xml
@@ -25,4 +25,12 @@
     <name>mapreduce.framework.name</name>
     <value>yarn</value>
   </property>
+  <property>
+    <name>mapreduce.admin.user.env</name>
+    <value>HADOOP_MAPRED_HOME=$HADOOP_COMMON_HOME</value>
+  </property>
+  <property>
+    <name>yarn.app.mapreduce.am.env</name>
+    <value>HADOOP_MAPRED_HOME=$HADOOP_COMMON_HOME</value>
+  </property>
 </configuration>


### PR DESCRIPTION
… in trunk so that MapReduce works again
